### PR TITLE
Added entrypoint.sh to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY generate_config.py /src/
 COPY scripts/certbot-renew-crontab.sh /etc/periodic/hourly/renew-postfix-tls
 COPY scripts/certbot-renew-posthook.sh /etc/letsencrypt/renewal-hooks/post/reload-postfix.sh
 COPY templates /src/templates
+COPY entrypoint.sh /src/docker-entrypoint.sh
 
 # Generate config, ask for a TLS certificate to Let's Encrypt, start Postfix and Cron daemon.
 WORKDIR /src


### PR DESCRIPTION
The start of the docker container would fail because there was no docker-entrypoint.sh in the image