### PR TITLE
Fix cron certbot renew

### DIFF
--- a/scripts/certbot-renew-crontab.sh
+++ b/scripts/certbot-renew-crontab.sh
@@ -5,7 +5,7 @@ CERTIFICATE="/etc/letsencrypt/live/$POSTFIX_FQDN/fullchain.pem"
 PRIVATE_KEY="/etc/letsencrypt/live/$POSTFIX_FQDN/privkey.pem"
 
 if [ -f $CERTIFICATE -a -f $PRIVATE_KEY ]; then
-    cerbot -n renew
+    certbot -q renew
 else
-    certbot -n certonly
+    certbot -q certonly
 fi

--- a/templates/certbot/cli.ini
+++ b/templates/certbot/cli.ini
@@ -1,4 +1,4 @@
-domain = {{ env['POSTFIX_FQDN'] }}
+domains = {{ env['POSTFIX_FQDN'] }}
 email = {{ env['LETSENCRYPT_EMAIL'] }}
 
 authenticator = standalone


### PR DESCRIPTION
automatic renewal would fail because there was a typo in `certbot-renew-crontab.sh` https://github.com/arugifa/simplelogin-postfix-docker/issues/5

certbot renew will not run if `domain` instead of `domains` is specified in cli.ini https://github.com/arugifa/simplelogin-postfix-docker/issues/6#

decreased cron verbosity