### PR TITLE
Update dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,16 @@ VOLUME /etc/letsencrypt
 # Install system dependencies.
 RUN apk add --update --no-cache \
     # Postfix itself:
-    postfix>=3.5 postfix-pgsql>=3.5 \
+    postfix>=3.6 postfix-pgsql>=3.6 \
     # To generate Postfix config files:
-    python3>=3.8 \
+    python3>=3.10 \
     # To generate and renew Postfix TLS certificate:
-    certbot>=1.20 \
+    certbot>=1.29.0 \
     dcron>=4.5 \
     bash
 
 # Install Python dependencies.
-RUN python3 -m ensurepip && pip3 install jinja2==2.11.3
+RUN python3 -m ensurepip && pip3 install jinja2==3.1.2
 
 # Copy sources.
 COPY generate_config.py /src/


### PR DESCRIPTION
Updates to dependencies for this docker image:

- Bumped minimum postfix version from 3.5 to 3.6.
- Bumped minimum python version from 3.8 to 3.10.
- Bumped minimum certbot version from 1.20.0 to 1.29.0.
- Updated jinja version from 2.11.3 to 3.1.2.
 