### PR TITLE
Add simplelogin compatibility mode to support both v3 and v4 deployme…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Setting     | Description
 **POSTFIX_FQDN** | Fully Qualified Domain Name of your Postfix instance (i.e., the MX server address you configured in your DNS zone for your **ALIASES_DEFAULT_DOMAIN**).
 **RELAY_HOST** | If your Postfix instance's IP address is blacklisted (e.g., because it is not a static address), you must use your Internet Service Provider's mail server as a relay, to be able to send emails to the outer world.
 **SSL_CERT_FOLDER** | Custom folder location for storing your own SSL certificate. This **disables** Let's Encrypt. Useful if you use a reverse proxy which manages your certificates. The certificate file name should be: ``fullchain.pem`` and the private key's file name should be: ``privkey.pem``.
+**SIMPLELOGIN_COMPATIBILITY_MODE** | Compatibility with Simplelogin major application version. The supported values are `v3` and `v4`. If not defined, it will default to `v3`.
 
 \* automatic renewal is managed with [Certbot](https://certbot.eff.org/) and shouldn't fail, unless you have reached Let's Encrypt [rate limits](https://letsencrypt.org/docs/rate-limits/)
 

--- a/examples/external-db-password-file/docker-compose.yml
+++ b/examples/external-db-password-file/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       POSTFIX_FQDN: mail.mydomain.com
       RELAY_HOST: myisp.internet.com
       # SSL_CERT_FOLDER: /mnt/certs
+      SIMPLELOGIN_COMPATIBILITY_MODE: v4
     secrets:
       - db_password
   

--- a/templates/postfix/pgsql-relay-domains.cf
+++ b/templates/postfix/pgsql-relay-domains.cf
@@ -4,6 +4,13 @@ user = {{ env['DB_USER'] }}
 password = {{ env['DB_PASSWORD'] }}
 dbname = {{ env['DB_NAME'] }}
 
+# --- Simplelogin Compatibility Mode: {{ env["SIMPLELOGIN_COMPATIBILITY_MODE"] }} ---
+
+{% if env['SIMPLELOGIN_COMPATIBILITY_MODE'] == 'v4' %}
+query = SELECT domain FROM custom_domain WHERE domain='%s' AND verified=true
+    UNION SELECT domain FROM public_domain WHERE domain='%s'
+    UNION SELECT '%s' WHERE '%s' = '{{ env["ALIASES_DEFAULT_DOMAIN"] }}' LIMIT 1;
+{% else %}
 query = SELECT domain FROM custom_domain WHERE domain='%s' AND verified=true
     UNION SELECT '%s' WHERE '%s' = '{{ env["ALIASES_DEFAULT_DOMAIN"] }}' LIMIT 1;
-
+{% endif %}

--- a/templates/postfix/pgsql-transport-maps.cf
+++ b/templates/postfix/pgsql-transport-maps.cf
@@ -4,7 +4,14 @@ user = {{ env['DB_USER'] }}
 password = {{ env['DB_PASSWORD'] }}
 dbname = {{ env['DB_NAME'] }}
 
-# forward to smtp:{{ env['EMAIL_HANDLER_HOST'] }}:20381 for custom domain AND email domain
+# --- Simplelogin Compatibility Mode: {{ env["SIMPLELOGIN_COMPATIBILITY_MODE"] }} ---
+
+# forward to smtp:{{ env["EMAIL_HANDLER_HOST"] }}:20381 for custom domain AND email domain
+{% if env['SIMPLELOGIN_COMPATIBILITY_MODE'] == 'v4' %}
+query = SELECT 'smtp:{{ env["EMAIL_HANDLER_HOST"] }}:20381' FROM custom_domain WHERE domain = '%s' AND verified=true
+    UNION SELECT 'smtp:{{ env["EMAIL_HANDLER_HOST"] }}:20381' FROM public_domain WHERE domain = '%s'
+    UNION SELECT 'smtp:{{ env["EMAIL_HANDLER_HOST"] }}:20381' WHERE '%s' = '{{ env["ALIASES_DEFAULT_DOMAIN"] }}' LIMIT 1;
+{% else %}
 query = SELECT 'smtp:{{ env["EMAIL_HANDLER_HOST"] }}:20381' FROM custom_domain WHERE domain = '%s' AND verified=true
     UNION SELECT 'smtp:{{ env["EMAIL_HANDLER_HOST"] }}:20381' WHERE '%s' = '{{ env["ALIASES_DEFAULT_DOMAIN"] }}' LIMIT 1;
-
+{% endif %}


### PR DESCRIPTION
I am not sure how important the database changes are in upgrade to v4. So in order to support the new `v4` deployment and also not break the older `v3` deployments. I have added the compatibility mode.

@nguyenkims Can you please review and provide your feedback.

Regards