### PR TITLE
Fix for hash and btree databases to replace them with `lmdb` as noted…

### DIFF
--- a/templates/postfix/main.cf
+++ b/templates/postfix/main.cf
@@ -27,8 +27,8 @@ smtpd_use_tls = yes
 smtp_tls_security_level = may
 smtpd_tls_cert_file = {{ tls_cert }}
 smtpd_tls_key_file = {{ tls_key }}
-smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
-smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+smtpd_tls_session_cache_database = lmdb:${data_directory}/smtpd_scache
+smtp_tls_session_cache_database = lmdb:${data_directory}/smtp_scache
 {% else %}
 smtpd_use_tls = no
 {% endif %}
@@ -36,7 +36,7 @@ smtpd_use_tls = no
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.
 
-alias_maps = hash:/etc/aliases
+alias_maps = lmdb:/etc/aliases
 
 # Allow containers on the same private network to send emails via Postfix.
 mynetworks_style = subnet


### PR DESCRIPTION
… in the [Alpine 3.13 Release notes ](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#Deprecation_of_Berkeley_DB_.28BDB.29)

Fixes #7 