### PR TITLE
Support SMTP Port / spamhaus DQS / main.cf generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN apk add --update --no-cache \
     dcron>=${DCRON_VERSION} \
     bash
 
+# Fix PEP 668 Externally Managed error
+RUN rm /usr/lib/python${PYTHON_VERSION}/EXTERNALLY-MANAGED
+
 # Install Python dependencies.
 RUN python3 -m ensurepip && pip3 install jinja2==${JINJA_VERSION}
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Setting     | Description
 **LETSENCRYPT_EMAIL** | Email address used by Let's Encrypt, to send you expiry notices\*.
 **POSTFIX_FQDN** | Fully Qualified Domain Name of your Postfix instance (i.e., the MX server address you configured in your DNS zone for your **ALIASES_DEFAULT_DOMAIN**).
 **RELAY_HOST** | If your Postfix instance's IP address is blacklisted (e.g., because it is not a static address), you must use your Internet Service Provider's mail server as a relay, to be able to send emails to the outer world. If **RELAY_HOST_USERNAME** and **RELAY_HOST_PASSWORD** specified in Docker Run / Compose, it will enable authentication to SMTP relay host.
+**RELAY_PORT** | SMTP Relay Host port.  Some relays require a specifc port (such as 587.
 **RELAY_HOST_USERNAME** | SMTP Relay Host username.
 **RELAY_HOST_PASSWORD** | SMTP Relay Host password. You can also use **RELAY_HOST_PASSWORD_FILE** if using with docker secrets.
+**POSTFIX_DQN_KEY** | If you use a recursive DNS (or are on a cloud provider such as Oracle or Amazon that means you are on a recursive DNS), you can't use the zen.spamhaus.org standard rbl.  Sign up for a free DQN key [here](https://www.spamhaus.com/free-trial/sign-up-for-a-free-data-query-service-account/) and add this to your config.
 **TLS_KEY_FILE** | Custom key file that provides custom TLS certificate. This **disables** Let's Encrypt. Useful if you use a reverse proxy which manages your certificates. If you are using Letsencrypt to get certificate, this file name would be: ``privkey.pem``.
 **TLS_CERT_FILE** | Custom certificate file that provides custom TLS certificate. This **disables** Let's Encrypt. Useful if you use a reverse proxy which manages your certificates. If you are using Letsencrypt to get certificate, this file name would be: ``fullchain.pem``.
 **SIMPLELOGIN_COMPATIBILITY_MODE** | Compatibility with Simplelogin major application version. The supported values are `v3` and `v4`. If not defined, it will default to `v3`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,6 +60,12 @@ setup_postfix_custom_data () {
   fi
 }
 
+setup_dnsbl_reply_map () {
+  if  [[ "${POSTFIX_DQN_KEY}" ]]; then
+    postmap lmdb:/etc/postfix/dnsbl-reply-map
+  fi
+}
+
 _main() {
   # Each environment variable that supports the *_FILE pattern needs to be passed into the file_env() function.
   file_env "DB_PASSWORD"
@@ -82,9 +88,9 @@ _main() {
   fi
 
   if [[ -f ${TLS_KEY_FILE} && -f ${TLS_CERT_FILE}  ]]; then
-    crond && python3 generate_config.py --postfix && postfix start-fg
+    crond && python3 generate_config.py --postfix && setup_dnsbl_reply_map && postfix start-fg
   else
-    python3 generate_config.py --certbot && certbot -n certonly; crond && python3 generate_config.py --postfix && postfix start-fg
+    python3 generate_config.py --certbot && certbot -n certonly; crond && python3 generate_config.py --postfix && setup_dnsbl_reply_map && postfix start-fg
   fi
 }
 

--- a/generate_config.py
+++ b/generate_config.py
@@ -25,7 +25,7 @@ LETSENCRYPT_PRIVATE_KEY = 'privkey.pem'
 
 # Postfix
 POSTFIX_CONFIG_DIR = Path('/etc/postfix')
-POSTFIX_CONFIG_FILENAMES = ['main.cf', 'pgsql-relay-domains.cf', 'pgsql-transport-maps.cf']  # noqa: E501
+POSTFIX_CONFIG_FILENAMES = ['main.cf', 'pgsql-relay-domains.cf', 'pgsql-transport-maps.cf', 'dnsbl-reply-map']  # noqa: E501
 
 # Templates
 TEMPLATES_DIR = Path('/src/templates')
@@ -47,6 +47,11 @@ def generate_certbot_config():
 def generate_postfix_config():
     """Generate Postfix's configuration files."""
     for filename in POSTFIX_CONFIG_FILENAMES:
+
+        # If DQN KEY is provided
+        if filename == 'dnsbl-reply-map' and environ.get('POSTFIX_DQN_KEY') is None:
+            # skip generation of mapping file - not needed.
+            continue
 
         filepath = POSTFIX_CONFIG_DIR / filename
         print(f"Generating Postfix configuration file: {filepath}")
@@ -79,6 +84,23 @@ def generate_postfix_config():
             else:
                 print("|Certificate files are present")            
 
+            # Existing checks for creds didn't seem to work using {% if 'RELAY_HOST_USERNAME' in env and 'RELAY_HOST_PASSWORD' in env %} 
+            # Generated main.cf didn't contain smtp_sasl_auth_enable = yes
+            # Following three tests address RELAY config settings
+
+            # Set up Relay Creds
+            relay_creds_flag = (environ.get('RELAY_HOST_USERNAME') is not None and environ.get('RELAY_HOST_PASSWORD') is not None)
+
+            # Set up Relay Host and Port
+            relay_host_port_flag = (environ.get('RELAY_HOST') is not None and environ.get('RELAY_PORT') is not None)
+
+            # Set up Relay Host Only
+            relay_host_only_flag = (environ.get('RELAY_HOST') is not None and environ.get('RELAY_HOST_PASSWORD') is None)
+
+            # Set up Use DQN
+            use_dqn_flag = environ.get('POSTFIX_DQN_KEY') is not None
+
+
             # Enable Proxy Protocal if postfix is behind a reverse proxy that can use Proxy Protocol like trafik or haproxy.
             enable_proxy_protocol = os.getenv("ENABLE_PROXY_PROTOCOL", 'False').lower() in ('true', '1', 't')
             if enable_proxy_protocol:
@@ -93,6 +115,10 @@ def generate_postfix_config():
                 tls_cert=cert_file,
                 tls_key=key_file,
                 proxy_protocol=enable_proxy_protocol,
+                relay_creds=relay_creds_flag,
+                relay_host_only=relay_host_only_flag,
+                relay_host_port=relay_host_port_flag,
+                use_dqn=use_dqn_flag,
             ))
 
 

--- a/templates/postfix/dnsbl-reply-map
+++ b/templates/postfix/dnsbl-reply-map
@@ -1,0 +1,6 @@
+{{ env['POSTFIX_DQN_KEY'] }}.zen.dq.spamhaus.net=127.0.0.[2..11]        554 $rbl_class $rbl_what blocked using ZEN - see https://www.spamhaus.org/query/ip/$client_address for details
+{{ env['POSTFIX_DQN_KEY'] }}.dbl.dq.spamhaus.net=127.0.1.[2..99]        554 $rbl_class $rbl_what blocked using DBL - see $rbl_txt for details
+{{ env['POSTFIX_DQN_KEY'] }}.zrd.dq.spamhaus.net=127.0.2.[2..24]        554 $rbl_class $rbl_what blocked using ZRD - domain too young
+{{ env['POSTFIX_DQN_KEY'] }}.zen.dq.spamhaus.net                        554 $rbl_class $rbl_what blocked using ZEN - see https://www.spamhaus.org/query/ip/$client_address for details
+{{ env['POSTFIX_DQN_KEY'] }}.dbl.dq.spamhaus.net                        554 $rbl_class $rbl_what blocked using DBL - see $rbl_txt for details
+{{ env['POSTFIX_DQN_KEY'] }}.zrd.dq.spamhaus.net                        554 $rbl_class $rbl_what blocked using ZRD - domain too young

--- a/templates/postfix/main.cf
+++ b/templates/postfix/main.cf
@@ -73,9 +73,26 @@ smtpd_recipient_restrictions =
    reject_unknown_recipient_domain,
    permit_mynetworks,
    reject_unauth_destination,
+   {% if use_dqn %}
+   # Add in dqn RBLs
+   reject_rbl_client {{ env['POSTFIX_DQN_KEY'] }}.zen.dq.spamhaus.net=127.0.0.[2..11],
+   reject_rhsbl_sender {{ env['POSTFIX_DQN_KEY'] }}.dbl.dq.spamhaus.net=127.0.1.[2..99],
+   reject_rhsbl_helo {{ env['POSTFIX_DQN_KEY'] }}.dbl.dq.spamhaus.net=127.0.1.[2..99],
+   reject_rhsbl_reverse_client {{ env['POSTFIX_DQN_KEY'] }}.dbl.dq.spamhaus.net=127.0.1.[2..99],
+   reject_rhsbl_sender {{ env['POSTFIX_DQN_KEY'] }}.zrd.dq.spamhaus.net=127.0.2.[2..24],
+   reject_rhsbl_helo {{ env['POSTFIX_DQN_KEY'] }}.zrd.dq.spamhaus.net=127.0.2.[2..24],
+   reject_rhsbl_reverse_client {{ env['POSTFIX_DQN_KEY'] }}.zrd.dq.spamhaus.net=127.0.2.[2..24],
+   {% else %}
+   # Use generics zen RBL
    reject_rbl_client zen.spamhaus.org,
+   {% endif %}
    reject_rbl_client bl.spamcop.net,
    permit
+
+{% if use_dqn %}
+# Add in map to mask dqn API KEY
+rbl_reply_maps = lmdb:$config_directory/dnsbl-reply-map
+{% endif %}
 
 # General TLS security improvements
 # Based on: https://kruyt.org/postfix-and-tls-encryption/
@@ -98,12 +115,17 @@ tls_preempt_cipherlist = yes
 # NO_RENEGOTIATION postfix 3.4 and openssl >1.1.1
 tls_ssl_options = NO_RENEGOTIATION
 
-{% if 'RELAY_HOST' in env %}
+{% if relay_host_port %}
+# Set email relay host with port:
+relayhost = {{ env['RELAY_HOST'] }}:{{ env['RELAY_PORT'] }}
+{% endif %}
+
+{% if relay_host_only %}
 # Set email relay host:
 relayhost = {{ env['RELAY_HOST'] }}
 {% endif %}
 
-{% if 'RELAY_HOST_USERNAME' in env and 'RELAY_HOST_PASSWORD' in env %}
+{% if relay_creds %}
 # Enable auth
 smtp_sasl_auth_enable = yes
 # Set username and password


### PR DESCRIPTION
Three key changes:
- Supports a port for SMTP relay (RELAY_PORT)
- Supports spamhaus Data Query Service
- Minor changes to config generation to work around issues noticed where RELAY_HOST and RELAY_HOST_USERNAME and RELAY_HOST_PASSWORD from config weren't generating appropriate entries in main.cf

Removed changes PEP 668 Externally Managed which prevented Dockerfile build - no longer required after including changes for PR#32

Tested on v4.6.5beta