### PR TITLE
Remove crond if pre-defined certificate files are provided.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,7 +88,7 @@ _main() {
   fi
 
   if [[ -f ${TLS_KEY_FILE} && -f ${TLS_CERT_FILE}  ]]; then
-    crond && python3 generate_config.py --postfix && setup_dnsbl_reply_map && postfix start-fg
+    python3 generate_config.py --postfix && setup_dnsbl_reply_map && postfix start-fg
   else
     python3 generate_config.py --certbot && certbot -n certonly; crond && python3 generate_config.py --postfix && setup_dnsbl_reply_map && postfix start-fg
   fi


### PR DESCRIPTION
This is a fix for a cron job running hourly even when the image is not used for maintaining the TLS certificates and the certificates are provided externally. This should fix #36 